### PR TITLE
Update Dockerfile and scheduler to set timezone and improve cron expressions

### DIFF
--- a/api-server/Dockerfile
+++ b/api-server/Dockerfile
@@ -23,6 +23,8 @@ RUN poetry export --without dev --without-hashes --no-interaction --no-ansi \
 ########################################################################################
 
 FROM python_base AS dev_final
+ENV TZ=Asia/Taipei
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && apt-get install -y git && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=dev_dependencies requirements.txt .
 RUN pip install --upgrade pip setuptools wheel && \
@@ -37,6 +39,8 @@ CMD ["gunicorn"]
 ########################################################################################
 
 FROM python_base AS prod_final
+ENV TZ=Asia/Taipei
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 COPY --from=production_dependencies requirements.txt .
 RUN pip install --upgrade pip setuptools wheel && \
     pip install -r requirements.txt --force-reinstall --no-warn-script-location

--- a/api-server/scheduler.py
+++ b/api-server/scheduler.py
@@ -73,19 +73,20 @@ if __name__ == "__main__":
         timezone=ZoneInfo("Asia/Taipei"),
     )
 
+    # NOTE: In the day_of_week field, 0 = Monday, 6 = Sunday
     scheduler.add_job(
         fetch_and_store_realtime_stock_info,
-        CronTrigger.from_crontab("* 9-13 * * 1-5"),
+        CronTrigger.from_crontab("* 9-13 * * mon-fri"),
         name="fetch_realtime_stock_info",
     )
     scheduler.add_job(
         update_all_stocks_history,
-        CronTrigger.from_crontab("0 15 * * 1-5"),
+        CronTrigger.from_crontab("0 15 * * mon-fri"),
         name="update_stock_history",
     )
     scheduler.add_job(
         update_material_facts,
-        CronTrigger.from_crontab("0 * * * 1-5"),
+        CronTrigger.from_crontab("0 * * * mon-fri"),
         name="update_material_facts",
     )
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -7,7 +7,7 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 RESET='\033[0m'
 
-SERVICES=(api-server frontend reverse-proxy db redis)
+SERVICES=(api-server frontend reverse-proxy db redis scheduler)
 
 check_triggered_by_make() {
     if [ -z "$MAKELEVEL" ]; then
@@ -40,7 +40,7 @@ clear_screen() {
 validate_service() {
     local service=$1
     if ! echo "${SERVICES[@]}" | grep -w "$service" >/dev/null; then
-        printf "${RED}Error: '$service' is not a valid service. Must be one of: ${SERVICES[@]}${RESET}\n"
+        printf "${RED}Error: '$service' is not a valid service.\nMust be one of: ${SERVICES[*]}${RESET}\n"
         exit 1
     fi
 }


### PR DESCRIPTION
- Added timezone configuration for Asia/Taipei in the Dockerfile for both development and production stages.
- Updated cron expressions in scheduler.py to use 'mon-fri' instead of numeric values for better readability.
- Modified common.sh to include 'scheduler' in the list of valid services.